### PR TITLE
Fix SlstrLevel1B1kmProductFactory so it works on Linux systems

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1B1kmProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1B1kmProductFactory.java
@@ -4,9 +4,6 @@ import org.esa.s3tbx.dataio.s3.Manifest;
 import org.esa.s3tbx.dataio.s3.Sentinel3ProductReader;
 import org.esa.snap.core.datamodel.Product;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -25,14 +22,11 @@ public class SlstrLevel1B1kmProductFactory extends SlstrLevel1FixedResolutionPro
 
     @Override
     protected List<String> getFileNames(Manifest manifest) {
-        final File directory = getInputFileParentDirectory();
-        final String[] fileNames = directory.list((dir, name) -> name.endsWith("in.nc") || name.endsWith("io.nc") || name.endsWith("tx.nc") ||
-                                                                 name.endsWith("tn.nc") || name.endsWith("to.nc"));
-
-        if (fileNames != null) {
-            return Arrays.asList(fileNames);
-        }
-        return Collections.emptyList();
+        List <String> fileNames = super.getFileNames(manifest);
+        fileNames.removeIf(name -> name.endsWith("an.nc") || name.endsWith("ao.nc") ||
+                                   name.endsWith("bn.nc") || name.endsWith("bo.nc") ||
+                                   name.endsWith("cn.nc") || name.endsWith("co.nc"));
+        return fileNames;
     }
 
     @Override


### PR DESCRIPTION
When opening SLSTR L1b files using the 1 km fixed resolution reader on Linux systems the products will sometimes be resized to the size of the tie-point grid (130 x 1200) rather than the size of the IR rasters (1500 x 1200 pixels). This appears to be a problem with how getFileNames works with the native (ext4) filesystem - if I read the product from a NTFS filesystem it opens correctly.

The PR avoids the problem by starting with the manifest list and removing the high resolution bands.

Removing the getFileNames override will also allow the 1 km product reader to work (the high resolution bands are resized to 1 km)