### PR TITLE
S3TBX-301: SLSTR L2 LST products can not be read

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLstProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLstProductFactory.java
@@ -83,6 +83,22 @@ public class SlstrLstProductFactory extends SlstrProductFactory {
     }
 
     @Override
+    protected short[] getResolutions(String gridIndex) {
+        short[] resolutions;
+        if (gridIndex.equals("tx") || gridIndex.equals("tn")) {
+            resolutions = new short[]{16000, 1000};
+        } else {
+            resolutions = new short[]{1000, 1000};
+        }
+        return resolutions;
+    }
+
+    @Override
+    protected short[] getReferenceResolutions() {
+        return new short[]{1000, 1000};
+    }
+
+    @Override
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         //todo extract values from metadata file as soon as they are provided
         int subSamplingX = 16;


### PR DESCRIPTION
No reference resolutions were set, because they were not required before 7.0.1. From what I've seen only SLSTR L2 LST is affected, but let's run the reader tests once.