### PR TITLE
Toniof s3tbx 302 303 reader fixes

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrFrpProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrFrpProductFactory.java
@@ -44,7 +44,7 @@ public class SlstrFrpProductFactory extends SlstrProductFactory {
         super.addProductSpecificMetadata(targetProduct);
         List<Product> openProductList = getOpenProductList();
         for (final Product p : openProductList) {
-            String identifier = p.getName().substring(p.getName().length() - 2);
+            String identifier = getGridIndex(p.getName());
             MetadataElement globalAttributes = p.getMetadataRoot().getElement("Global_Attributes");
             if (!gridIndexToStartOffset.containsKey(identifier)) {
                 gridIndexToStartOffset.put(identifier, globalAttributes.getAttributeDouble("start_offset"));
@@ -96,13 +96,13 @@ public class SlstrFrpProductFactory extends SlstrProductFactory {
     protected void setBandGeoCodings(Product targetProduct) {
         final Band[] bands = targetProduct.getBands();
         for (Band band : bands) {
-            final GeoCoding bandGeoCoding = getBandGeoCoding(targetProduct, band.getName().substring(band.getName().length() - 2));
+            final GeoCoding bandGeoCoding = getBandGeoCoding(targetProduct, getGridIndex(band.getName()));
             band.setGeoCoding(bandGeoCoding);
         }
         final ProductNodeGroup<Mask> maskGroup = targetProduct.getMaskGroup();
         for (int i = 0; i < maskGroup.getNodeCount(); i++) {
             final Mask mask = maskGroup.get(i);
-            final GeoCoding bandGeoCoding = getBandGeoCoding(targetProduct, mask.getName().substring(mask.getName().length() - 2));
+            final GeoCoding bandGeoCoding = getBandGeoCoding(targetProduct, getGridIndex(mask.getName()));
             mask.setGeoCoding(bandGeoCoding);
         }
     }
@@ -110,11 +110,7 @@ public class SlstrFrpProductFactory extends SlstrProductFactory {
     @Override
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         final String sourceBandName = sourceBand.getName();
-        final int sourceBandNameLength = sourceBandName.length();
-        String gridIndex = sourceBandName;
-        if (sourceBandNameLength > 1) {
-            gridIndex = sourceBandName.substring(sourceBandNameLength - 2);
-        }
+        String gridIndex = getGridIndex(sourceBandName);
         // todo wait for name change. If this happens, we can merge this with the method from SlstrLevel1ProductFactory
         if (sourceBand.getName().equals("flags")) {
             gridIndex = "in";

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1FixedResolutionProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1FixedResolutionProductFactory.java
@@ -20,11 +20,7 @@ public abstract class SlstrLevel1FixedResolutionProductFactory extends SlstrLeve
     @Override
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         final String sourceBandName = sourceBand.getName();
-        final int sourceBandNameLength = sourceBandName.length();
-        String gridIndex = sourceBandName;
-        if(sourceBandNameLength > 1) {
-            gridIndex = sourceBandName.substring(sourceBandNameLength - 2);
-        }
+        String gridIndex = getGridIndex(sourceBandName);
         final Double sourceStartOffset = getStartOffset(gridIndex);
         final Double sourceTrackOffset = getTrackOffset(gridIndex);
         if (sourceStartOffset != null && sourceTrackOffset != null) {

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1ProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1ProductFactory.java
@@ -270,16 +270,15 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
 
     protected void configureDescription(Band sourceBand, RasterDataNode targetNode) {
         final String sourceBandName = sourceBand.getName();
-        final String sourceBandNameEnd = sourceBandName.substring(sourceBandName.length() - 2);
-        if (sourceBandNameEnd.startsWith("i") || sourceBandNameEnd.startsWith("f")) {
+        String gridIndex = getGridIndex(sourceBandName);
+        if (gridIndex.startsWith("i") || gridIndex.startsWith("f")) {
             String description = sourceBand.getDescription();
             if (description == null) {
                 targetNode.setDescription("(1 km)");
             } else {
                 targetNode.setDescription(description + " (1 km)");
             }
-        } else if (sourceBandNameEnd.startsWith("a") || sourceBandName.startsWith("b") ||
-                   sourceBandName.startsWith("c")) {
+        } else if (gridIndex.startsWith("a") || sourceBandName.startsWith("b") || sourceBandName.startsWith("c")) {
             String description = sourceBand.getDescription();
             if (description == null) {
                 targetNode.setDescription("(500 m)");
@@ -323,11 +322,7 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
     @Override
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         final String sourceBandName = sourceBand.getName();
-        final int sourceBandNameLength = sourceBandName.length();
-        String gridIndex = sourceBandName;
-        if (sourceBandNameLength > 1) {
-            gridIndex = sourceBandName.substring(sourceBandNameLength - 2);
-        }
+        String gridIndex = getGridIndex(sourceBandName);
         final Double sourceStartOffset = getStartOffset(gridIndex);
         final Double sourceTrackOffset = getTrackOffset(gridIndex);
         if (sourceStartOffset != null && sourceTrackOffset != null) {
@@ -431,7 +426,7 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
 //        if (Config.instance("s3tbx").load().preferences().getBoolean(SLSTR_L1B_USE_PIXELGEOCODINGS, false)) {
 //            final Band[] bands = product.getBands();
 //            for (Band band : bands) {
-//                final GeoCoding bandGeoCoding = getBandGeoCoding(product, band.getName().substring(band.getName().length() - 2));
+//                final GeoCoding bandGeoCoding = getBandGeoCoding(product, getGridIndex(band.getName));
 //                final SlstrGeoCodingSceneTransformProvider transformProvider =
 //                        new SlstrGeoCodingSceneTransformProvider(product.getSceneGeoCoding(), bandGeoCoding);
 //                band.setModelToSceneTransform(transformProvider.getModelToSceneTransform());
@@ -440,7 +435,7 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
 //            final ProductNodeGroup<Mask> maskGroup = product.getMaskGroup();
 //            for (int i = 0; i < maskGroup.getNodeCount(); i++) {
 //                final Mask mask = maskGroup.get(i);
-//                final GeoCoding bandGeoCoding = getBandGeoCoding(product, mask.getName().substring(mask.getName().length() - 2));
+//                final GeoCoding bandGeoCoding = getBandGeoCoding(product, getGridIndex(mask.getName()));
 //                final SlstrGeoCodingSceneTransformProvider transformProvider =
 //                        new SlstrGeoCodingSceneTransformProvider(product.getSceneGeoCoding(), bandGeoCoding);
 //                mask.setModelToSceneTransform(transformProvider.getModelToSceneTransform());
@@ -517,7 +512,7 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
     private void setTiePointBandGeoCodings(Product product) {
         final Band[] bands = product.getBands();
         for (Band band : bands) {
-            setTiePointBandGeoCoding(product, band, band.getName().substring(band.getName().length() - 2));
+            setTiePointBandGeoCoding(product, band, getGridIndex(band.getName()));
         }
         final ProductNodeGroup<Mask> maskGroup = product.getMaskGroup();
         for (int i = 0; i < maskGroup.getNodeCount(); i++) {
@@ -563,13 +558,13 @@ public class SlstrLevel1ProductFactory extends SlstrProductFactory {
     private void setPixelBandGeoCodings(Product product) {
         final Band[] bands = product.getBands();
         for (Band band : bands) {
-            final GeoCoding bandGeoCoding = getBandGeoCoding(product, band.getName().substring(band.getName().length() - 2));
+            final GeoCoding bandGeoCoding = getBandGeoCoding(product, getGridIndex(band.getName()));
             band.setGeoCoding(bandGeoCoding);
         }
         final ProductNodeGroup<Mask> maskGroup = product.getMaskGroup();
         for (int i = 0; i < maskGroup.getNodeCount(); i++) {
             final Mask mask = maskGroup.get(i);
-            final GeoCoding bandGeoCoding = getBandGeoCoding(product, mask.getName().substring(mask.getName().length() - 2));
+            final GeoCoding bandGeoCoding = getBandGeoCoding(product, getGridIndex(mask.getName()));
             mask.setGeoCoding(bandGeoCoding);
         }
     }

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLstProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLstProductFactory.java
@@ -83,6 +83,22 @@ public class SlstrLstProductFactory extends SlstrProductFactory {
     }
 
     @Override
+    protected short[] getResolutions(String gridIndex) {
+        short[] resolutions;
+        if (gridIndex.equals("tx") || gridIndex.equals("tn")) {
+            resolutions = new short[]{16000, 1000};
+        } else {
+            resolutions = new short[]{1000, 1000};
+        }
+        return resolutions;
+    }
+
+    @Override
+    protected short[] getReferenceResolutions() {
+        return new short[]{1000, 1000};
+    }
+
+    @Override
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         //todo extract values from metadata file as soon as they are provided
         int subSamplingX = 16;

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrProductFactory.java
@@ -46,6 +46,22 @@ public abstract class SlstrProductFactory extends AbstractProductFactory {
         super(productReader);
     }
 
+    static String getGridIndex(String bandName) {
+        String[] nameParts = bandName.split("_");
+        int lastPartIndex = nameParts.length - 1;
+        int index = lastPartIndex;
+        while (index >= 0) {
+            if (nameParts[index].length() == 2) {
+                return nameParts[index];
+            }
+            index--;
+        }
+        if (nameParts[lastPartIndex].length() > 1) {
+            return nameParts[lastPartIndex].substring(nameParts[lastPartIndex].length() - 2);
+        }
+        return nameParts[lastPartIndex];
+    }
+
     protected abstract Double getStartOffset(String gridIndex);
 
     protected abstract Double getTrackOffset(String gridIndex);
@@ -80,7 +96,7 @@ public abstract class SlstrProductFactory extends AbstractProductFactory {
 
     @Override
     protected boolean isNodeSpecial(Band sourceBand, Product targetProduct) {
-        String identifier = sourceBand.getName().substring(sourceBand.getName().length() - 2);
+        String identifier = getGridIndex(sourceBand.getName());
         return super.isNodeSpecial(sourceBand, targetProduct) || getStartOffset(identifier) != referenceStartOffset ||
                 getTrackOffset(identifier) != referenceTrackOffset ||
                 getResolutions(identifier)[0] != getReferenceResolutions()[0] ||

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrSstProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrSstProductFactory.java
@@ -128,7 +128,7 @@ public class SlstrSstProductFactory extends SlstrProductFactory {
     protected RasterDataNode addSpecialNode(Product masterProduct, Band sourceBand, Product targetProduct) {
         final String sourceBandName = sourceBand.getName();
         final String sourceProductName = sourceBand.getProduct().getName();
-        final String gridIndex = (sourceProductName).substring(sourceProductName.length() - 2);
+        final String gridIndex = getGridIndex(sourceProductName);
         Double sourceStartOffset = getStartOffset(gridIndex);
         Double sourceTrackOffset = getTrackOffset(gridIndex);
         final short[] sourceResolutions = getResolutions(gridIndex);

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrWstProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrWstProductFactory.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 
 public class SlstrWstProductFactory extends SlstrSstProductFactory {
 
+    private static final short[] RESOLUTIONS = new short[]{1000, 1000};
+
     public SlstrWstProductFactory(Sentinel3ProductReader productReader) {
         super(productReader);
     }
@@ -80,6 +82,26 @@ public class SlstrWstProductFactory extends SlstrSstProductFactory {
                 }
             }
         }
+    }
+
+    @Override
+    protected Double getStartOffset(String gridIndex) {
+        return 0.0;
+    }
+
+    @Override
+    protected Double getTrackOffset(String gridIndex) {
+        return 0.0;
+    }
+
+    @Override
+    protected short[] getResolutions(String gridIndex) {
+        return RESOLUTIONS;
+    }
+
+    @Override
+    protected short[] getReferenceResolutions() {
+        return RESOLUTIONS;
     }
 
     @Override

--- a/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrGeoCodingSceneTransformProviderTest.java
+++ b/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrGeoCodingSceneTransformProviderTest.java
@@ -8,8 +8,7 @@ import org.opengis.referencing.operation.TransformException;
 
 import java.awt.geom.Point2D;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * @author Tonio Fincke

--- a/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrProductFactoryTest.java
+++ b/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrProductFactoryTest.java
@@ -1,0 +1,23 @@
+package org.esa.s3tbx.dataio.s3.slstr;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SlstrProductFactoryTest {
+
+    @Test
+    public void testGetGridIndex() {
+        assertEquals("in", SlstrProductFactory.getGridIndex("a_name_ending_in_in"));
+        assertEquals("io", SlstrProductFactory.getGridIndex("a_name_ending_in_io"));
+        assertEquals("fn", SlstrProductFactory.getGridIndex("a_name_ending_in_fn"));
+        assertEquals("tx", SlstrProductFactory.getGridIndex("a_name_ending_in_tx"));
+        assertEquals("in", SlstrProductFactory.getGridIndex("a_name_ending_in_in_lsb"));
+        assertEquals("io", SlstrProductFactory.getGridIndex("a_name_ending_in_io_msb"));
+        assertEquals("y", SlstrProductFactory.getGridIndex("y"));
+        assertEquals("th", SlstrProductFactory.getGridIndex("th_fetrzgh"));
+        assertEquals("gh", SlstrProductFactory.getGridIndex("the_fetrzgh"));
+        assertEquals("f", SlstrProductFactory.getGridIndex("thtcfzghj_f"));
+        assertEquals("-f", SlstrProductFactory.getGridIndex("thtcfzghj-f"));
+    }
+
+}

--- a/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrTiePointGeoCodingTest.java
+++ b/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/slstr/SlstrTiePointGeoCodingTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import java.awt.geom.AffineTransform;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 /**
  * @author Tonio Fincke


### PR DESCRIPTION
Fixes for s3tbx-302 and s3tbx-303. The issue for the WST products was that the correct resolutions could not be found. For the products from the 4th reprocessing, a wrong gridindex was found because one band (x_in) was split into more and less significant bytes (x_in_msb and x_in_lsb). I have improved and harmonized the determination of the grid index. Weirdly, while this affected several classes, none of them was the AatsrLevel1ProductFactory.