### PR TITLE
Fixing category discrepances

### DIFF
--- a/s3tbx-meris-cloud/src/main/java/org/esa/s3tbx/operator/cloud/CloudOperator.java
+++ b/s3tbx-meris-cloud/src/main/java/org/esa/s3tbx/operator/cloud/CloudOperator.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 @SuppressWarnings({"UnusedDeclaration", "FieldCanBeLocal"})
 @OperatorMetadata(alias = "CloudProb",
-        category = "Optical/Pre-Processing/Masking",
+        category = "Optical/Preprocessing/Masking",
         version = "1.7",
         authors = "Rene Preusker (Algorithm), Tom Block (BEAM Implementation), Thomas Storm (GPF conversion)",
         copyright = "Copyright (C) 2004-2014 by ESA, FUB and Brockmann Consult",

--- a/s3tbx-meris-radiometry/src/main/java/org/esa/s3tbx/meris/radiometry/MerisRadiometryCorrectionOp.java
+++ b/s3tbx-meris-radiometry/src/main/java/org/esa/s3tbx/meris/radiometry/MerisRadiometryCorrectionOp.java
@@ -74,7 +74,7 @@ import static org.esa.snap.dataio.envisat.EnvisatConstants.*;
         description = "Performs radiometric corrections on MERIS L1b data products.",
         authors = "Marc Bouvet (ESTEC); Marco Peters, Ralf Quast, Thomas Storm, Marco Zuehlke (Brockmann Consult)",
         copyright = "(c) 2015 by Brockmann Consult",
-        category = "Optical/Pre-Processing",
+        category = "Optical/Preprocessing",
         version = "1.2")
 public class MerisRadiometryCorrectionOp extends SampleOperator {
 

--- a/s3tbx-meris-sdr/src/main/java/org/esa/s3tbx/meris/brr/operator/BrrOp.java
+++ b/s3tbx-meris-sdr/src/main/java/org/esa/s3tbx/meris/brr/operator/BrrOp.java
@@ -36,7 +36,7 @@ import java.util.Map;
                   authors = "R. Santer, M. Zuehlke, T. Block, O. Danne",
                   copyright = "(c) European Space Agency",
                   description = "Performs the Rayleigh correction on a MERIS L1b product.",
-                  category = "Optical/Pre-Processing")
+                  category = "Optical/Preprocessing")
 public class BrrOp extends BrrBasisOp {
 
     private static final float NODATA_VALUE = -1.0f;

--- a/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/operator/Radiometry.java
+++ b/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/operator/Radiometry.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
         description = "Performs radiometric corrections on OLCI L1b data products.",
         authors = " Marco Peters ,Muhammad Bala (Brockmann Consult)",
         copyright = "(c) 2015 by Brockmann Consult",
-        category = "Optical/Pre-Processing",
+        category = "Optical/Preprocessing",
         version = "1.2")
 
 public class Radiometry extends Operator {

--- a/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/rayleigh/RayleighCorrectionOp.java
+++ b/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/rayleigh/RayleighCorrectionOp.java
@@ -53,7 +53,7 @@ import static org.esa.s3tbx.olci.radiometry.smilecorr.SmileCorrectionUtils.*;
         description = "Performs radiometric corrections on OLCI, MERIS L1B and S2 MSI L1C data products.",
         authors = "Marco Peters, Muhammad Bala, Olaf Danne (Brockmann Consult)",
         copyright = "(c) 2016 by Brockmann Consult",
-        category = "Optical/Pre-Processing",
+        category = "Optical/Preprocessing",
         version = "1.3")
 public class RayleighCorrectionOp extends Operator {
 

--- a/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/smilecorr/SmileCorrectionOp.java
+++ b/s3tbx-olci-radiometry/src/main/java/org/esa/s3tbx/olci/radiometry/smilecorr/SmileCorrectionOp.java
@@ -55,7 +55,7 @@ import static org.esa.s3tbx.olci.radiometry.smilecorr.SmileCorrectionUtils.*;
         description = "Performs radiometric corrections on OLCI L1b data products.",
         authors = " Marco Peters, Muhammad Bala (Brockmann Consult)",
         copyright = "(c) 2015 by Brockmann Consult",
-        category = "Optical/Pre-Processing",
+        category = "Optical/Preprocessing",
         version = "1.2.2")
 public class SmileCorrectionOp extends Operator {
 

--- a/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/Rad2ReflOp.java
+++ b/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/Rad2ReflOp.java
@@ -52,7 +52,7 @@ import static org.esa.snap.dataio.envisat.EnvisatConstants.MERIS_DETECTOR_INDEX_
 @OperatorMetadata(alias = "Rad2Refl",
         authors = "Olaf Danne, Marco Peters",
         copyright = "Brockmann Consult GmbH",
-        category = "Optical/Pre-Processing",
+        category = "Optical/Preprocessing",
         version = "2.0",
         description = "Provides conversion from radiances to reflectances or backwards.")
 public class Rad2ReflOp extends Operator {


### PR DESCRIPTION
I am trying to uniform the Graph Builder menus with the main window menus, to do so the category in the operator descriptor must be the same as the one in the main menu. 