### PR TITLE
S3TBX-328: Rad2Refl Operator cannot handle latest SLSTR input products

### DIFF
--- a/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/Rad2ReflOp.java
+++ b/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/Rad2ReflOp.java
@@ -33,9 +33,10 @@ import org.esa.snap.core.image.ResolutionLevel;
 import org.esa.snap.core.image.VirtualBandOpImage;
 import org.esa.snap.core.util.ProductUtils;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.awt.image.Raster;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -96,12 +97,7 @@ public class Rad2ReflOp extends Operator {
     @Override
     public void initialize() throws OperatorException {
         spectralInputBandPrefix = isRadToReflMode() ? "radiance" : "reflectance";
-        spectralInputBandNames = isRadToReflMode() ? sensor.getRadBandNames() : sensor.getReflBandNames();
-        spectralOutputBandNames = isRadToReflMode() ? sensor.getReflBandNames() : sensor.getRadBandNames();
-
-        Product targetProduct = createTargetProduct();
-        setTargetProduct(targetProduct);
-
+        setInputAndOutputBands();
         boolean spectralBandsAvailable = productHasAllSpectralBands(spectralInputBandNames);
         if (sensor == Sensor.MERIS && spectralBandsAvailable) {
             setupInvalidImage(Sensor.MERIS.getInvalidPixelExpression());
@@ -109,22 +105,44 @@ public class Rad2ReflOp extends Operator {
             try {
                 rad2ReflAuxdata = Rad2ReflAuxdata.loadMERISAuxdata(sourceProduct.getProductType());
             } catch (IOException e) {
-                e.printStackTrace();
+                throw new OperatorException(e);
             }
         } else if (sensor == Sensor.OLCI && spectralBandsAvailable) {
             setupInvalidImage(Sensor.OLCI.getInvalidPixelExpression());
             converter = new OlciRadReflConverter(conversionMode);
-        } else if (sensor == Sensor.SLSTR_500m && spectralBandsAvailable) {
+        } else if (sensor == Sensor.SLSTR_500m) {
             slstrSolarFluxMap = SlstrRadReflConverter.getSolarFluxMapFromQualityMetadata(sourceProduct,
                                                                                          spectralInputBandNames,
                                                                                          isRadToReflMode());
-            slstrInvalidImages = SlstrRadReflConverter.createInvalidImages(sourceProduct);
+            slstrInvalidImages = SlstrRadReflConverter.
+                    createInvalidImages(sourceProduct, spectralInputBandNames, isRadToReflMode());
             converter = new SlstrRadReflConverter(conversionMode);
         } else {
             throw new OperatorException
                     ("Sensor '" + sensor.getName() + "' not compliant with input product. Please check your selection.");
         }
+        Product targetProduct = createTargetProduct();
+        setTargetProduct(targetProduct);
+    }
 
+    private void setInputAndOutputBands() {
+        if (sensor == Sensor.SLSTR_500m) {
+            String[] allSpectralInputBandNames = isRadToReflMode() ? sensor.getRadBandNames() : sensor.getReflBandNames();
+            String[] allSpectralOutputBandNames = isRadToReflMode() ? sensor.getReflBandNames() : sensor.getRadBandNames();
+            List<String> spectralInputBandNameList = new ArrayList<>();
+            List<String> spectralOutputBandNameList = new ArrayList<>();
+            for (int i = 0; i < allSpectralInputBandNames.length; i++) {
+                if (sourceProduct.containsBand(allSpectralInputBandNames[i])) {
+                    spectralInputBandNameList.add(allSpectralInputBandNames[i]);
+                    spectralOutputBandNameList.add(allSpectralOutputBandNames[i]);
+                }
+            }
+            spectralInputBandNames = spectralInputBandNameList.toArray(new String[0]);
+            spectralOutputBandNames = spectralOutputBandNameList.toArray(new String[0]);
+        } else {
+            spectralInputBandNames = isRadToReflMode() ? sensor.getRadBandNames() : sensor.getReflBandNames();
+            spectralOutputBandNames = isRadToReflMode() ? sensor.getReflBandNames() : sensor.getRadBandNames();
+        }
     }
 
     @Override
@@ -248,17 +266,12 @@ public class Rad2ReflOp extends Operator {
         targetProduct = new Product(sourceProduct.getName(), sourceProduct.getProductType(),
                                     sourceProduct.getSceneRasterWidth(), sourceProduct.getSceneRasterHeight());
 
-        for (int i = 0; i < sensor.getNumSpectralBands(); i++) {
+        for (int i = 0; i < spectralInputBandNames.length; i++) {
+            Band sourceBand = sourceProduct.getBand(spectralInputBandNames[i]);
             if (isRadToReflMode()) {
-                Band sourceBand = sourceProduct.getBand(sensor.getRadBandNames()[i]);
-                if (sourceBand != null) {
-                    createReflectanceBand(sourceBand, sensor.getReflBandNames()[i]);
-                }
+                createReflectanceBand(sourceBand, spectralOutputBandNames[i]);
             } else {
-                Band sourceBand = sourceProduct.getBand(sensor.getReflBandNames()[i]);
-                if (sourceBand != null) {
-                    createRadianceBand(sourceBand, sensor.getRadBandNames()[i]);
-                }
+                createRadianceBand(sourceBand, spectralOutputBandNames[i]);
             }
         }
 

--- a/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/SlstrRadReflConverter.java
+++ b/s3tbx-rad2refl/src/main/java/org/esa/s3tbx/processor/rad2refl/SlstrRadReflConverter.java
@@ -64,14 +64,15 @@ public class SlstrRadReflConverter implements RadReflConverter {
         return map;
     }
 
-    static VirtualBandOpImage[] createInvalidImages(Product sourceProduct) {
-        VirtualBandOpImage[] invalidImages = new VirtualBandOpImage[Sensor.SLSTR_500m.getNumSpectralBands()];
-
-        for (int i = 0; i < Sensor.SLSTR_500m.getNumSpectralBands(); i++) {
-            final String bandName = Sensor.SLSTR_500m.getRadBandNames()[i];
-            String unfilledPixelExpression = bandName.replace("radiance", "exception") + ".unfilled_pixel";
-            String saturationExpression = bandName.replace("radiance", "exception") + ".saturation";
-            String invalidRadianceExpression = bandName.replace("radiance", "exception") + ".invalid_radiance";
+    static VirtualBandOpImage[] createInvalidImages(Product sourceProduct, String[] inputBandNames,
+                                                    boolean isRad2ReflMode) {
+        VirtualBandOpImage[] invalidImages = new VirtualBandOpImage[inputBandNames.length];
+        String replacer = isRad2ReflMode ? "radiance" : "reflectance";
+        for (int i = 0; i < inputBandNames.length; i++) {
+            final String bandName = inputBandNames[i];
+            String unfilledPixelExpression = bandName.replace(replacer, "exception") + ".unfilled_pixel";
+            String saturationExpression = bandName.replace(replacer, "exception") + ".saturation";
+            String invalidRadianceExpression = bandName.replace(replacer, "exception") + ".invalid_radiance";
             String invalidExpression = unfilledPixelExpression + " || " +
                     saturationExpression + " || " + invalidRadianceExpression;
             invalidImages[i] = VirtualBandOpImage.builder(invalidExpression, sourceProduct)


### PR DESCRIPTION
This commit serves to fix the issue that the latest generation of SLSTR products cannot be read, i.e., that bands from the c-channel must be present. The behaviour for MERIS and OLCI stays the same, though: They still will not be able to work with a subset of spectral bands. I guess it would make sense to harmonize the behaviour and, while we're at it, refactor a few things towards a more sensor-independent processor, but that would go beyond this fix.