### PR TITLE
S3TBX-341: The 'Use pixel-based GeoCoding' is not considered for SLSTR products when opened on fixed resolution

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1FixedResolutionProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrLevel1FixedResolutionProductFactory.java
@@ -42,11 +42,4 @@ public abstract class SlstrLevel1FixedResolutionProductFactory extends SlstrLeve
         return sourceBand;
     }
 
-    @Override
-    protected void setSceneTransforms(Product product) {
-    }
-
-    @Override
-    protected void setBandGeoCodings(Product product) {
-    }
 }


### PR DESCRIPTION
Solves https://senbox.atlassian.net/browse/SIIITBX-341 .
It's really that simple. Just allow to set band geocodings. I tried and it works just fine.