### PR TITLE
Toniof snap1334 tpg subsetting is slow

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/Sentinel3ProductReader.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/Sentinel3ProductReader.java
@@ -39,6 +39,7 @@ import org.esa.snap.core.datamodel.Product;
 import org.esa.snap.core.datamodel.ProductData;
 import org.esa.snap.core.datamodel.TiePointGrid;
 
+import java.awt.Rectangle;
 import java.awt.image.Raster;
 import java.io.File;
 import java.io.IOException;
@@ -122,7 +123,8 @@ public class Sentinel3ProductReader extends AbstractProductReader {
     public void readTiePointGridRasterData(TiePointGrid tpg, int destOffsetX, int destOffsetY, int destWidth, int destHeight, ProductData destBuffer,
                                            ProgressMonitor pm) {
         MultiLevelImage imageForTpg = factory.getImageForTpg(tpg.getName());
-        Raster imageData = imageForTpg.getImage(0).getData();
+        Rectangle rectangle = new Rectangle(destOffsetX, destOffsetY, destWidth, destHeight);
+        Raster imageData = imageForTpg.getImage(0).getData(rectangle);
         imageData.getSamples(destOffsetX, destOffsetY, destWidth, destHeight, 0, (float[]) destBuffer.getElems());
     }
 

--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/util/S3VariableOpImage.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/util/S3VariableOpImage.java
@@ -65,8 +65,6 @@ public class S3VariableOpImage extends SingleBandedOpImage {
 
     @Override
     protected void computeRect(PlanarImage[] sourceImages, WritableRaster tile, Rectangle rectangle) {
-//        System.out.println(variable.getFullName() + ": " + tile.getMinX() + ", " + tile.getMinY() + ", " +
-//                                   tile.getWidth() + ", " + tile.getHeight());
         final int rank = variable.getRank();
         final int[] origin = new int[rank];
         final int[] shape = new int[rank];


### PR DESCRIPTION
Complementary PR to https://github.com/senbox-org/snap-engine/pull/243 . This will ensure that only the portion of a tie-point grid that is actually requested is read.