### PR TITLE
OLCI fractional accuracy with per-pixel geo-coding

### DIFF
--- a/s3tbx-sentinel3-reader-ui/src/main/java/org/esa/s3tbx/dataio/s3/preferences/ui/S3ReaderOptionsPanel.java
+++ b/s3tbx-sentinel3-reader-ui/src/main/java/org/esa/s3tbx/dataio/s3/preferences/ui/S3ReaderOptionsPanel.java
@@ -28,6 +28,7 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
     private JCheckBox slstrL1BS3MPCRecommendationCheckBox;
     private JCheckBox slstrL2SSTPixelGeocodingsCheckBox;
     private JCheckBox olciPixelGeocodingsCheckBox;
+    private JCheckBox olciPixelGeocodingFractionalAccuracyCheckBox;
     private JCheckBox olciL1CalibrationCheckBox;
     private JCheckBox merisPixelGeocodingsCheckBox;
 
@@ -40,6 +41,7 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
         slstrL1BS3MPCRecommendationCheckBox.addItemListener(e -> controller.changed());
         slstrL2SSTPixelGeocodingsCheckBox.addItemListener(e -> controller.changed());
         olciPixelGeocodingsCheckBox.addItemListener(e -> controller.changed());
+        olciPixelGeocodingFractionalAccuracyCheckBox.addItemListener(e -> controller.changed());
         olciL1CalibrationCheckBox.addItemListener(e -> controller.changed());
         merisPixelGeocodingsCheckBox.addItemListener(e -> controller.changed());
     }
@@ -69,6 +71,10 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
         Mnemonics.setLocalizedText(olciPixelGeocodingsCheckBox,
                                    NbBundle.getMessage(S3ReaderOptionsPanel.class,
                                                        "S3TBXReaderOptionsPanel.olciPixelGeocodingsCheckBox.text")); // NOI18N
+        olciPixelGeocodingFractionalAccuracyCheckBox = new JCheckBox();
+        Mnemonics.setLocalizedText(olciPixelGeocodingFractionalAccuracyCheckBox,
+                                   NbBundle.getMessage(S3ReaderOptionsPanel.class,
+                                                       "S3TBXReaderOptionsPanel.olciPixelGeocodingFractionalAccuracyCheckBox.text")); // NOI18N
         olciL1CalibrationCheckBox = new JCheckBox();
         Mnemonics.setLocalizedText(olciL1CalibrationCheckBox,
                                    NbBundle.getMessage(S3ReaderOptionsPanel.class,
@@ -104,6 +110,8 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
                                                             .addGap(0, 512, Short.MAX_VALUE)
                                                             .addComponent(olciPixelGeocodingsCheckBox)
                                                             .addGap(0, 512, Short.MAX_VALUE)
+                                                            .addComponent(olciPixelGeocodingFractionalAccuracyCheckBox)
+                                                            .addGap(0, 512, Short.MAX_VALUE)
                                                             .addComponent(olciL1CalibrationCheckBox)
                                                             .addGap(0, 512, Short.MAX_VALUE)
                                                             .addComponent(merisLabel)
@@ -130,6 +138,8 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
                                           .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                           .addComponent(olciPixelGeocodingsCheckBox)
                                           .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                          .addComponent(olciPixelGeocodingFractionalAccuracyCheckBox)
+                                          .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                           .addComponent(olciL1CalibrationCheckBox)
                                           .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                           .addComponent(merisLabel)
@@ -153,6 +163,8 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
                 preferences.getBoolean(SlstrSstProductFactory.SLSTR_L2_SST_USE_PIXELGEOCODINGS, false));
         olciPixelGeocodingsCheckBox.setSelected(
                 preferences.getBoolean(OlciProductFactory.OLCI_USE_PIXELGEOCODING, false));
+        olciPixelGeocodingFractionalAccuracyCheckBox.setSelected(
+                preferences.getBoolean(OlciProductFactory.OLCI_USE_FRACTIONAL_ACCURACY, false));
         olciL1CalibrationCheckBox.setSelected(
                 preferences.getBoolean(OlciLevel1ProductFactory.OLCI_L1_CUSTOM_CALIBRATION, false));
         merisPixelGeocodingsCheckBox.setSelected(
@@ -172,6 +184,7 @@ final class S3ReaderOptionsPanel extends javax.swing.JPanel {
         preferences.putBoolean(SlstrSstProductFactory.SLSTR_L2_SST_USE_PIXELGEOCODINGS,
                                slstrL2SSTPixelGeocodingsCheckBox.isSelected());
         preferences.putBoolean(OlciProductFactory.OLCI_USE_PIXELGEOCODING, olciPixelGeocodingsCheckBox.isSelected());
+        preferences.putBoolean(OlciProductFactory.OLCI_USE_FRACTIONAL_ACCURACY, olciPixelGeocodingFractionalAccuracyCheckBox.isSelected());
         preferences.putBoolean(OlciLevel1ProductFactory.OLCI_L1_CUSTOM_CALIBRATION, olciL1CalibrationCheckBox.isSelected());
         preferences.putBoolean(MerisProductFactory.MERIS_SAFE_USE_PIXELGEOCODING, merisPixelGeocodingsCheckBox.isSelected());
         try {

--- a/s3tbx-sentinel3-reader-ui/src/main/resources/org/esa/s3tbx/dataio/s3/preferences/ui/Bundle.properties
+++ b/s3tbx-sentinel3-reader-ui/src/main/resources/org/esa/s3tbx/dataio/s3/preferences/ui/Bundle.properties
@@ -4,6 +4,7 @@ S3TBXReaderOptionsPanel.slstrL1BCalibrationFactorCheckBox.text=Read Sentinel-S3 
 S3TBXReaderOptionsPanel.slstrL1BS3MPCRecommendationCheckBox.text=S3MPC recommendation to adjust SLSTR L1B S5 and S6 radiometric calibration
 S3TBXReaderOptionsPanel.slstrL2SSTPixelGeocodingsCheckBox.text=Read Sentinel-3 SLSTR L2 WCT products with per-pixel geo-codings instead of using tie-points
 S3TBXReaderOptionsPanel.olciPixelGeocodingsCheckBox.text=Read Sentinel-3 OLCI products with per-pixel geo-coding instead of using tie-points
+S3TBXReaderOptionsPanel.olciPixelGeocodingFractionalAccuracyCheckBox.text=Use fractional accuracy in Sentinel-3 OLCI products with activated per-pixel geo-coding
 S3TBXReaderOptionsPanel.olciL1CalibrationCheckBox.text=Read Sentinel-S3 OLCI L1 with custom calibration
 S3TBXReaderOptionsPanel.merisPixelGeocodingsCheckBox.text=Read ENVISAT MERIS products in SAFE format with per-pixel geo-coding instead of using tie-points
 S3TBXReaderOptionsPanel.loadProfileTiepointsCheckBox.text=Read Sentinel-3 products with profile tie-point data

--- a/s3tbx-sentinel3-reader-ui/src/main/resources/org/esa/s3tbx/dataio/s3/preferences/ui/docs/s3tbx/S3TBXOptions.html
+++ b/s3tbx-sentinel3-reader-ui/src/main/resources/org/esa/s3tbx/dataio/s3/preferences/ui/docs/s3tbx/S3TBXOptions.html
@@ -110,6 +110,10 @@
         When using tie-point geo-coding, the product is opened quicker,
         using the per-pixel geo-coding will lead to more precise results.
     </li>
+    <li><b>Use fractional accuracy in Sentinel-3 OLCI products with activated per-pixel geo-coding</b><br>
+        When geo-coding is pixel-based, a sub-pixel fraction accuracy shall be used.
+        This leads to a more precise result in the reprojection if bilinear or bicubic interpolation was chosen for the reprojection.
+    </li>
     <li><b>Read Sentinel-3 OLCI L1 product with custom calibration</b><br>
         This option provides a way to set scaling factors and offsets to OLCI L1 bands.
         When switched on, the S3TBX will consider factors and offsets given in the <i><b>s3tbx.properties</b></i> file.<br>

--- a/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/olci/OlciProductFactoryTest.java
+++ b/s3tbx-sentinel3-reader/src/test/java/org/esa/s3tbx/dataio/s3/olci/OlciProductFactoryTest.java
@@ -43,20 +43,20 @@ public class OlciProductFactoryTest {
 
     @Test
     public void testGetForwardAndInverseKeys_pixelCoding_fractionalAccuracy() {
-        final String fractionalAccuracy = System.getProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY);
+        final String fractionalAccuracy = System.getProperty(OLCI_USE_FRACTIONAL_ACCURACY);
 
         try {
-            System.setProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY, "true");
+            System.setProperty(OLCI_USE_FRACTIONAL_ACCURACY, "true");
 
             final String[] codingKeys = OlciProductFactory.getForwardAndInverseKeys_pixelCoding();
             assertEquals("FWD_PIXEL_INTERPOLATING", codingKeys[0]);
-            assertEquals("INV_PIXEL_QUAD_TREE", codingKeys[1]);
+            assertEquals("INV_PIXEL_QUAD_TREE_INTERPOLATING", codingKeys[1]);
 
         } finally {
             if (fractionalAccuracy != null) {
-                System.setProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY, fractionalAccuracy);
+                System.setProperty(OLCI_USE_FRACTIONAL_ACCURACY, fractionalAccuracy);
             } else {
-                System.clearProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY);
+                System.clearProperty(OLCI_USE_FRACTIONAL_ACCURACY);
             }
         }
     }
@@ -103,12 +103,12 @@ public class OlciProductFactoryTest {
     public void testGetForwardAndInverseKeys_pixelCoding_default() {
         final String forwardKey = System.getProperty(SYSPROP_OLCI_PIXEL_CODING_FORWARD);
         final String inverseKey = System.getProperty(SYSPROP_OLCI_PIXEL_CODING_INVERSE);
-        final String fractionalAccuracy = System.getProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY);
+        final String fractionalAccuracy = System.getProperty(OLCI_USE_FRACTIONAL_ACCURACY);
 
         try {
             System.clearProperty(SYSPROP_OLCI_PIXEL_CODING_INVERSE);
             System.clearProperty(SYSPROP_OLCI_PIXEL_CODING_FORWARD);
-            System.clearProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY);
+            System.clearProperty(OLCI_USE_FRACTIONAL_ACCURACY);
 
             final String[] codingKeys = OlciProductFactory.getForwardAndInverseKeys_pixelCoding();
             assertEquals("FWD_PIXEL", codingKeys[0]);
@@ -122,7 +122,7 @@ public class OlciProductFactoryTest {
                 System.setProperty(SYSPROP_OLCI_PIXEL_CODING_INVERSE, inverseKey);
             }
             if (fractionalAccuracy != null) {
-                System.setProperty(SYSPROP_OLCI_USE_FRACTIONAL_ACCURACY, fractionalAccuracy);
+                System.setProperty(OLCI_USE_FRACTIONAL_ACCURACY, fractionalAccuracy);
             }
         }
     }


### PR DESCRIPTION
Switch for use fractional accuracy in Sentinel-3 OLCI products with activated per-pixel geo-coding

- Please double check the English texts in the modified help and the internationalisation properties file.