### PR TITLE
SEADAS-reader-fixes-8.x

### DIFF
--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOciFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOciFileReader.java
@@ -82,8 +82,7 @@ public class L1BPaceOciFileReader extends SeadasFileReader {
 
             // somehow there are duplicate bands in the test file.
             // fixme
-            swir_wavlengths = Array.factory(DataType.INT, new int[]{940, 1038, 1250, 1251, 1378, 1615, 1616, 2130, 2260});
-
+            swir_wavlengths = Array.makeArray(DataType.DOUBLE, new String[] {"940", "1038", "1250", "1251", "1378", "1615", "1616", "2130", "2260"});
         } catch (IOException e) {
             throw new ProductIOException(e.getMessage(), e);
         }

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOcisFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOcisFileReader.java
@@ -82,8 +82,7 @@ public class L1BPaceOcisFileReader extends SeadasFileReader {
 
             // somehow there are duplicate bands in the test file.
             // fixme
-            swir_wavlengths = Array.factory(DataType.INT, new int[]{940, 1038, 1250, 1251, 1378, 1615, 1616, 2130, 2260});
-
+            swir_wavlengths = Array.makeArray(DataType.DOUBLE, new String[] {"940", "1038", "1250", "1251", "1378", "1615", "1616", "2130", "2260"});
 
 
         } catch (IOException e) {

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasFileReader.java
@@ -1237,6 +1237,8 @@ public abstract class SeadasFileReader {
             } else if (attribute.isArray()) {
                 productData = ProductData.createInstance(productDataType, attribute.getLength());
                 productData.setElems(attribute.getValues().getStorage());
+            } else if (attribute.getValues() == null) {
+                productData = ProductData.createInstance(" ");
             } else {
                 productData = ProductData.createInstance(productDataType, 1);
                 productData.setElems(attribute.getValues().getStorage());


### PR DESCRIPTION
seadas-reader: fixed number type bug in reading PACE data, and also fixed bug in SeadasFileReader which occurs in VIIRS L1B file reading due to null attributes in the L1B file.