### PR TITLE
use width and height of lon band for GeoRaster

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrSstProductFactory.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/slstr/SlstrSstProductFactory.java
@@ -296,8 +296,8 @@ public class SlstrSstProductFactory extends SlstrProductFactory {
             final double[] longitudes = RasterUtils.loadGeoData(lonBand);
             final double[] latitudes = RasterUtils.loadGeoData(latBand);
 
-            final int width = product.getSceneRasterWidth();
-            final int height = product.getSceneRasterHeight();
+            final int width = lonBand.getRasterWidth();
+            final int height = lonBand.getRasterHeight();
             final GeoRaster geoRaster = new GeoRaster(longitudes, latitudes, lonVariableName, latVariableName,
                                                       width, height, 1.0);
 


### PR DESCRIPTION
Product size is wrong if bands have different geo-coding and size.