### PR TITLE
SEADAS Reader: 3d bands plus PACE,MERIS,HICO fixes (master branch)

### DIFF
--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BHicoProductReaderPlugIn.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BHicoProductReaderPlugIn.java
@@ -74,25 +74,28 @@ public class L1BHicoProductReaderPlugIn implements ProductReaderPlugIn {
         try {
             ncfile = NetcdfFileOpener.open(file.getPath());
             if (ncfile != null) {
-                Attribute instrumentName = ncfile.findGlobalAttribute("metadata_FGDC_Instrument_Information_Instrument_Name");
+                Attribute instrumentName = ncfile.findGlobalAttribute("instrument");
+                Attribute processingLevel = ncfile.findGlobalAttribute("processing_level");
 
                 //metadata/FGDC/Instrument_Information/Instrument_Name = "Hyperspectral Imager for Coastal Oceans"
 
                 if (instrumentName != null) {
-                    if (instrumentName.toString().contains("Hyperspectral Imager for Coastal Oceans")) {
-                        if (DEBUG) {
-                            System.out.println(file);
+                    if (processingLevel != null) {
+                        if (instrumentName.getStringValue().equals("HICO") && processingLevel.getStringValue().equals("L1B")) {
+                            if (DEBUG) {
+                                System.out.println(file);
+                            }
+                            ncfile.close();
+                            return DecodeQualification.INTENDED;
                         }
-                        ncfile.close();
-                        return DecodeQualification.INTENDED;
                     } else {
                         if (DEBUG) {
-                            System.out.println("# Unrecognized instrument name=[" + instrumentName + "]: " + file);
+                            System.out.println("# Missing processing_level attribute: " + file);
                         }
                     }
                 } else {
                     if (DEBUG) {
-                        System.out.println("# Missing Instrument_Name attribute': " + file);
+                        System.out.println("# Missing instrument attribute': " + file);
                     }
                 }
             } else {

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOciFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOciFileReader.java
@@ -86,8 +86,9 @@ public class L1BPaceOciFileReader extends SeadasFileReader {
         } catch (IOException e) {
             throw new ProductIOException(e.getMessage(), e);
         }
-        mustFlipX = mustFlipY = getDefaultFlip();
-
+//        mustFlipX = mustFlipY = getDefaultFlip();
+        mustFlipY = getDefaultFlip();
+        mustFlipX = false;
         SeadasProductReader.ProductType productType = productReader.getProductType();
 
         Product product = new Product(productName, productType.toString(), sceneWidth, sceneHeight);

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOcisFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L1BPaceOcisFileReader.java
@@ -88,8 +88,9 @@ public class L1BPaceOcisFileReader extends SeadasFileReader {
         } catch (IOException e) {
             throw new ProductIOException(e.getMessage(), e);
         }
-        mustFlipX = mustFlipY = getDefaultFlip();
-
+//        mustFlipX = mustFlipY = getDefaultFlip();
+        mustFlipY = getDefaultFlip();
+        mustFlipX = false;
         SeadasProductReader.ProductType productType = productReader.getProductType();
 
         Product product = new Product(productName, productType.toString(), sceneWidth, sceneHeight);

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L2FileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/L2FileReader.java
@@ -35,7 +35,7 @@ import java.util.List;
  * User: seadas
  * Date: 11/14/11
  * Time: 2:23 PM
-  */
+ */
 public class L2FileReader extends SeadasFileReader {
 
     private static final String KEEP_BAD_NAV_PROPERTY = "snap.seadasl2reader.keepBadNavLines";
@@ -54,12 +54,12 @@ public class L2FileReader extends SeadasFileReader {
         List<Dimension> dims = ncFile.getDimensions();
         for (Dimension d: dims){
             if ((d.getShortName().equalsIgnoreCase("number_of_lines"))
-            ||(d.getShortName().equalsIgnoreCase("Number_of_Scan_Lines")))
-                    {
+                    ||(d.getShortName().equalsIgnoreCase("Number_of_Scan_Lines")))
+            {
                 sceneHeight = d.getLength();
             }
             if ((d.getShortName().equalsIgnoreCase("pixels_per_line"))
-            || (d.getShortName().equalsIgnoreCase("Pixels_per_Scan_Line"))){
+                    || (d.getShortName().equalsIgnoreCase("Pixels_per_Scan_Line"))){
                 sceneWidth = d.getLength();
             }
         }
@@ -98,7 +98,9 @@ public class L2FileReader extends SeadasFileReader {
         mustFlipX = mustFlipY = getDefaultFlip();
         SeadasProductReader.ProductType productType = productReader.getProductType();
         if (productType == SeadasProductReader.ProductType.Level1A_CZCS ||
-                productType == SeadasProductReader.ProductType.Level2_CZCS)
+                productType == SeadasProductReader.ProductType.Level2_CZCS ||
+                productType == SeadasProductReader.ProductType.Level2_PaceOCI ||
+                productType == SeadasProductReader.ProductType.Level2_PaceOCIS)
             mustFlipX = false;
 
         Product product = new Product(productName, productType.toString(), sceneWidth, sceneHeight);
@@ -242,11 +244,11 @@ public class L2FileReader extends SeadasFileReader {
                         latTiePoints = (float[]) latarr.flip(0).flip(1).copyTo1DJavaArray();
                         lonTiePoints = (float[]) lonarr.flip(0).flip(1).copyTo1DJavaArray();
                     } else if (!mustFlipX && mustFlipY) {
-                            latTiePoints = (float[]) latarr.flip(0).copyTo1DJavaArray();
-                            lonTiePoints = (float[]) lonarr.flip(0).copyTo1DJavaArray();
+                        latTiePoints = (float[]) latarr.flip(0).copyTo1DJavaArray();
+                        lonTiePoints = (float[]) lonarr.flip(0).copyTo1DJavaArray();
                     } else if (mustFlipX && !mustFlipY) {
-                            latTiePoints = (float[]) latarr.flip(1).copyTo1DJavaArray();
-                            lonTiePoints = (float[]) lonarr.flip(1).copyTo1DJavaArray();
+                        latTiePoints = (float[]) latarr.flip(1).copyTo1DJavaArray();
+                        lonTiePoints = (float[]) lonarr.flip(1).copyTo1DJavaArray();
                     } else {
                         latTiePoints = (float[]) latarr.getStorage();
                         lonTiePoints = (float[]) lonarr.getStorage();
@@ -257,7 +259,7 @@ public class L2FileReader extends SeadasFileReader {
                     product.addTiePointGrid(latGrid);
 
                     final TiePointGrid lonGrid = new TiePointGrid("longitude", dims[1], dims[0], 0, 0,
-			    subSampleX, subSampleY, lonTiePoints, TiePointGrid.DISCONT_AT_180);
+                            subSampleX, subSampleY, lonTiePoints, TiePointGrid.DISCONT_AT_180);
                     product.addTiePointGrid(lonGrid);
 
                     product.setSceneGeoCoding(new BowtieTiePointGeoCoding(latGrid, lonGrid, scanHeight));
@@ -338,7 +340,7 @@ public class L2FileReader extends SeadasFileReader {
                             latRawData, lonRawData, colPoints);
 
                 } catch (IOException e) {
-                   throw new ProductIOException(e.getMessage(), e);
+                    throw new ProductIOException(e.getMessage(), e);
                 }
             }
         }

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasFileReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasFileReader.java
@@ -43,9 +43,21 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static java.lang.String.format;
 import static java.lang.System.arraycopy;
+
+/**
+ * NASA SeaDAS File Reader.
+ *
+ * @author NASA OBPG
+ * @version $Revision$ $Date$
+ * @since
+ */
+//APR2021 - Bing Yang - added capability to read 3d products
+
 
 public abstract class SeadasFileReader {
 
@@ -65,6 +77,7 @@ public abstract class SeadasFileReader {
 
     private static final String FLAG_MASKS = "flag_masks";
     private static final String FLAG_MEANINGS = "flag_meanings";
+    protected Logger logger = Logger.getLogger(getClass().getSimpleName());
 
     protected static final SkipBadNav LAT_SKIP_BAD_NAV = new SkipBadNav() {
         @Override
@@ -83,8 +96,8 @@ public abstract class SeadasFileReader {
     public abstract Product createProduct() throws IOException;
 
     public synchronized void readBandData(Band destBand, int sourceOffsetX, int sourceOffsetY, int sourceWidth,
-            int sourceHeight, int sourceStepX, int sourceStepY, ProductData destBuffer,
-            ProgressMonitor pm) throws IOException, InvalidRangeException {
+                                          int sourceHeight, int sourceStepX, int sourceStepY, ProductData destBuffer,
+                                          ProgressMonitor pm) throws IOException, InvalidRangeException {
 
         if (mustFlipY) {
             sourceOffsetY = destBand.getRasterHeight() - (sourceOffsetY + sourceHeight);
@@ -747,13 +760,19 @@ public abstract class SeadasFileReader {
     }
 
     public Map<Band, Variable> addBands(Product product,
-            List<Variable> variables) {
-        final Map<Band, Variable> bandToVariableMap = new HashMap<Band, Variable>();
+                                        List<Variable> variables) {
+        Map<Band, Variable> bandToVariableMap = new HashMap<Band, Variable>();
         for (Variable variable : variables) {
-            Band band = addNewBand(product, variable);
-            if (band != null) {
-                bandToVariableMap.put(band, variable);
+            int variableRank = variable.getRank();
+            if (variableRank == 2) {
+                Band band = addNewBand(product, variable);
+                if (band != null) {
+                    bandToVariableMap.put(band, variable);
+                }
+            } else if (variableRank == 3) {
+                add3DNewBands(product, variable, bandToVariableMap);
             }
+
         }
         setSpectralBand(product);
 
@@ -778,6 +797,125 @@ public abstract class SeadasFileReader {
         }
     }
 
+    protected Map<Band, Variable> add3DNewBands(Product product, Variable variable, Map<Band, Variable> bandToVariableMap ) {
+        final int sceneRasterWidth = product.getSceneRasterWidth();
+        final int sceneRasterHeight = product.getSceneRasterHeight();
+
+        int spectralBandIndex = 0;
+        Array wavelengths = null;
+
+        final int[] dimensions = variable.getShape();
+        final int bands = dimensions[2];
+        final int height = dimensions[0];
+        final int width = dimensions[1];
+
+        if (height == sceneRasterHeight && width == sceneRasterWidth) {
+            // final List<Attribute> list = variable.getAttributes();
+
+            Variable wvl = ncFile.findVariable("sensor_band_parameters/wavelength");
+            try {
+                wavelengths = wvl.read();
+            } catch (IOException e) {
+            }
+
+            for (int i = 0; i < bands; i++) {
+                final String shortname = variable.getShortName();
+                StringBuilder longname = new StringBuilder(shortname);
+                longname.append("_");
+                longname.append(wavelengths.getInt(i));
+                String name = longname.toString();
+                final int dataType = getProductDataType(variable);
+
+                if(!product.containsBand(name)) {
+
+                    final Band band = new Band(name, dataType, width, height);
+                    product.addBand(band);
+
+                    Variable sliced = null;
+                    try {
+                        sliced = variable.slice(2, i);
+                    } catch (InvalidRangeException e) {
+                        e.printStackTrace();  //Todo change body of catch statement.
+                    }
+                    bandToVariableMap.put(band, sliced);
+
+                    try {
+                        Attribute fillValue = variable.findAttribute("_FillValue");
+                        if (fillValue == null) {
+                            fillValue = variable.findAttribute("bad_value_scaled");
+                        }
+                        band.setNoDataValue((double) fillValue.getNumericValue().floatValue());
+                        band.setNoDataValueUsed(true);
+                    } catch (Exception ignored) {
+                    }
+
+                    final List<Attribute> list = variable.getAttributes();
+                    double[] validMinMax = {0.0, 0.0};
+                    for (Attribute attribute : list) {
+                        final String attribName = attribute.getShortName();
+                        if ("units".equals(attribName)) {
+                            band.setUnit(attribute.getStringValue());
+                        } else if ("long_name".equals(attribName)) {
+                            band.setDescription(attribute.getStringValue());
+                        } else if ("slope".equals(attribName)) {
+                            band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
+                        } else if ("intercept".equals(attribName)) {
+                            band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
+                        } else if ("scale_factor".equals(attribName)) {
+                            band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
+                        } else if ("add_offset".equals(attribName)) {
+                            band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
+                        } else if (attribName.startsWith("valid_")) {
+                            if ("valid_min".equals(attribName)) {
+                                if (attribute.getDataType().isUnsigned()) {
+                                    validMinMax[0] = getUShortAttribute(attribute);
+                                } else {
+                                    validMinMax[0] = attribute.getNumericValue(0).doubleValue();
+                                }
+                            } else if ("valid_max".equals(attribName)) {
+                                if (attribute.getDataType().isUnsigned()) {
+                                    validMinMax[1] = getUShortAttribute(attribute);
+                                } else {
+                                    validMinMax[1] = attribute.getNumericValue(0).doubleValue();
+                                }
+                            } else if ("valid_range".equals(attribName)) {
+                                validMinMax[0] = attribute.getNumericValue(0).doubleValue();
+                                validMinMax[1] = attribute.getNumericValue(1).doubleValue();
+                            }
+                        }
+                    }
+                    if (validMinMax[0] != validMinMax[1]) {
+                        String validExp;
+                        if (ncFile.getFileTypeId().equalsIgnoreCase("HDF4")) {
+                            validExp = format("%s >= %.05f && %s <= %.05f", name, validMinMax[0], name, validMinMax[1]);
+
+                        } else {
+                            double[] minmax = {0.0, 0.0};
+                            minmax[0] = validMinMax[0];
+                            minmax[1] = validMinMax[1];
+
+                            if (band.getScalingFactor() != 1.0) {
+                                minmax[0] *= band.getScalingFactor();
+                                minmax[1] *= band.getScalingFactor();
+                            }
+                            if (band.getScalingOffset() != 0.0) {
+                                minmax[0] += band.getScalingOffset();
+                                minmax[1] += band.getScalingOffset();
+                            }
+                            validExp = format("%s >= %.05f && %s <= %.05f", name, minmax[0], name, minmax[1]);
+
+                        }
+                        band.setValidPixelExpression(validExp);//.format(name, validMinMax[0], name, validMinMax[1]));
+                    }
+                } else {
+                    logger.log(Level.WARNING, "The Product '" + product.getName() + "' contains duplicate bands" +
+                            " with the name '" + name + "', one will be ignored.");
+                }
+            }
+        }
+        return bandToVariableMap;
+    }
+
     protected Band addNewBand(Product product, Variable variable) {
         final int sceneRasterWidth = product.getSceneRasterWidth();
         final int sceneRasterHeight = product.getSceneRasterHeight();
@@ -791,77 +929,84 @@ public abstract class SeadasFileReader {
             if (height == sceneRasterHeight && width == sceneRasterWidth) {
                 final String name = variable.getShortName();
                 final int dataType = getProductDataType(variable);
-                band = new Band(name, dataType, width, height);
 
-                product.addBand(band);
+                if (!product.containsBand(name)) {
 
-                try {
-                    Attribute fillValue = variable.findAttribute("_FillValue");
-                    if (fillValue == null) {
-                        fillValue = variable.findAttribute("bad_value_scaled");
+                    band = new Band(name, dataType, width, height);
+
+                    product.addBand(band);
+
+                    try {
+                        Attribute fillValue = variable.findAttribute("_FillValue");
+                        if (fillValue == null) {
+                            fillValue = variable.findAttribute("bad_value_scaled");
+                        }
+                        band.setNoDataValue((double) fillValue.getNumericValue().floatValue());
+                        band.setNoDataValueUsed(true);
+                    } catch (Exception ignored) {
                     }
-                    band.setNoDataValue((double) fillValue.getNumericValue().floatValue());
-                    band.setNoDataValueUsed(true);
-                } catch (Exception ignored) {
-                }
 
-                final List<Attribute> list = variable.getAttributes();
-                double[] validMinMax = {0.0, 0.0};
-                for (Attribute attribute : list) {
-                    final String attribName = attribute.getShortName();
-                    if ("units".equals(attribName)) {
-                        band.setUnit(attribute.getStringValue());
-                    } else if ("long_name".equals(attribName)) {
-                        band.setDescription(attribute.getStringValue());
-                    } else if ("slope".equals(attribName)) {
-                        band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
-                    } else if ("intercept".equals(attribName)) {
-                        band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
-                    } else if ("scale_factor".equals(attribName)) {
-                        band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
-                    } else if ("add_offset".equals(attribName)) {
-                        band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
-                    } else if (attribName.startsWith("valid_")) {
-                        if ("valid_min".equals(attribName)) {
-                            if (attribute.getDataType().isUnsigned()) {
-                                validMinMax[0] = getUShortAttribute(attribute);
-                            } else {
+                    final List<Attribute> list = variable.getAttributes();
+                    double[] validMinMax = {0.0, 0.0};
+                    for (Attribute attribute : list) {
+                        final String attribName = attribute.getShortName();
+                        if ("units".equals(attribName)) {
+                            band.setUnit(attribute.getStringValue());
+                        } else if ("long_name".equals(attribName)) {
+                            band.setDescription(attribute.getStringValue());
+                        } else if ("slope".equals(attribName)) {
+                            band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
+                        } else if ("intercept".equals(attribName)) {
+                            band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
+                        } else if ("scale_factor".equals(attribName)) {
+                            band.setScalingFactor(attribute.getNumericValue(0).doubleValue());
+                        } else if ("add_offset".equals(attribName)) {
+                            band.setScalingOffset(attribute.getNumericValue(0).doubleValue());
+                        } else if (attribName.startsWith("valid_")) {
+                            if ("valid_min".equals(attribName)) {
+                                if (attribute.getDataType().isUnsigned()) {
+                                    validMinMax[0] = getUShortAttribute(attribute);
+                                } else {
+                                    validMinMax[0] = attribute.getNumericValue(0).doubleValue();
+                                }
+                            } else if ("valid_max".equals(attribName)) {
+                                if (attribute.getDataType().isUnsigned()) {
+                                    validMinMax[1] = getUShortAttribute(attribute);
+                                } else {
+                                    validMinMax[1] = attribute.getNumericValue(0).doubleValue();
+                                }
+                            } else if ("valid_range".equals(attribName)) {
                                 validMinMax[0] = attribute.getNumericValue(0).doubleValue();
+                                validMinMax[1] = attribute.getNumericValue(1).doubleValue();
                             }
-                        } else if ("valid_max".equals(attribName)) {
-                            if (attribute.getDataType().isUnsigned()) {
-                                validMinMax[1] = getUShortAttribute(attribute);
-                            } else {
-                                validMinMax[1] = attribute.getNumericValue(0).doubleValue();
-                            }
-                        } else if ("valid_range".equals(attribName)) {
-                            validMinMax[0] = attribute.getNumericValue(0).doubleValue();
-                            validMinMax[1] = attribute.getNumericValue(1).doubleValue();
                         }
                     }
-                }
-                if (validMinMax[0] != validMinMax[1]) {
-                    String validExp;
-                    if (ncFile.getFileTypeId().equalsIgnoreCase("HDF4")) {
-                        validExp = format("%s >= %.05f && %s <= %.05f", name, validMinMax[0], name, validMinMax[1]);
+                    if (validMinMax[0] != validMinMax[1]) {
+                        String validExp;
+                        if (ncFile.getFileTypeId().equalsIgnoreCase("HDF4")) {
+                            validExp = format("%s >= %.05f && %s <= %.05f", name, validMinMax[0], name, validMinMax[1]);
 
-                    } else {
-                        double[] minmax = {0.0, 0.0};
-                        minmax[0] = validMinMax[0];
-                        minmax[1] = validMinMax[1];
+                        } else {
+                            double[] minmax = {0.0, 0.0};
+                            minmax[0] = validMinMax[0];
+                            minmax[1] = validMinMax[1];
 
-                        if (band.getScalingFactor() != 1.0) {
-                            minmax[0] *= band.getScalingFactor();
-                            minmax[1] *= band.getScalingFactor();
+                            if (band.getScalingFactor() != 1.0) {
+                                minmax[0] *= band.getScalingFactor();
+                                minmax[1] *= band.getScalingFactor();
+                            }
+                            if (band.getScalingOffset() != 0.0) {
+                                minmax[0] += band.getScalingOffset();
+                                minmax[1] += band.getScalingOffset();
+                            }
+                            validExp = format("%s >= %.05f && %s <= %.05f", name, minmax[0], name, minmax[1]);
+
                         }
-                        if (band.getScalingOffset() != 0.0) {
-                            minmax[0] += band.getScalingOffset();
-                            minmax[1] += band.getScalingOffset();
-                        }
-                        validExp = format("%s >= %.05f && %s <= %.05f", name, minmax[0], name, minmax[1]);
-
+                        band.setValidPixelExpression(validExp);//.format(name, validMinMax[0], name, validMinMax[1]));
                     }
-                    band.setValidPixelExpression(validExp);//.format(name, validMinMax[0], name, validMinMax[1]));
+                } else {
+                    logger.log(Level.WARNING, "The Product '" + product.getName() + "' contains duplicate" +
+                            "bands with the name '" + name + "', one will be ignored.");
                 }
             }
         }
@@ -963,8 +1108,8 @@ public abstract class SeadasFileReader {
     }
 
     public void computeLatLonBandData(int height, int width, Band latBand, Band lonBand,
-            final float[] latRawData, final float[] lonRawData,
-            final int[] colPoints) {
+                                      final float[] latRawData, final float[] lonRawData,
+                                      final int[] colPoints) {
 
         float[] latFloats = new float[height * width];
         float[] lonFloats = new float[height * width];
@@ -1130,7 +1275,7 @@ public abstract class SeadasFileReader {
 
     private ProductData.UTC getUTCAttribute(String key, List<Attribute> globalAttributes) {
         Attribute attribute = findAttribute(key, globalAttributes);
-         if (attribute != null) {
+        if (attribute != null) {
             String timeString = attribute.getStringValue().trim();
             return parseUtcDate(timeString);
         }
@@ -1319,31 +1464,41 @@ public abstract class SeadasFileReader {
         try {
             int lineCount = shape[0];
             final int[] start = new int[]{0, 0};
-            // just grab the first and last pixel for each scan line
-            final int[] stride = new int[]{1, shape[1] - 1};
             final int[] count = new int[]{shape[0], shape[1]};
-            Section section = new Section(start, count, stride);
+            Section section = new Section(start, count);
             Array array;
             synchronized (ncFile) {
                 array = latitude.read(section);
             }
             for (int i = 0; i < lineCount; i++) {
-                int ix = i * 2;
-                float valstart = array.getFloat(ix);
-                float valend = array.getFloat(ix + 1);
-                if (skipBadNav.isBadNav(valstart) || skipBadNav.isBadNav(valend)) {
+                boolean find_valstart = false;
+                for (int j = 0; j < shape[1]; j++) {
+                    float valstart = array.getFloat(i * shape[1] + j);
+                    if (!skipBadNav.isBadNav(valstart)) {
+                        find_valstart = true;
+                        break;
+                    }
+                }
+                if (!find_valstart) {
                     leadLineSkip++;
-                } else {
+                }
+                else{
                     break;
                 }
             }
             for (int i = lineCount; i-- > 0;) {
-                int ix = i * 2;
-                float valstart = array.getFloat(ix);
-                float valend = array.getFloat(ix + 1);
-                if (skipBadNav.isBadNav(valstart) || skipBadNav.isBadNav(valend)) {
+                boolean find_valstart = false;
+                for (int j = 0; j < shape[1]; j++) {
+                    float valstart = array.getFloat(i * shape[1] + j);
+                    if (!skipBadNav.isBadNav(valstart)) {
+                        find_valstart = true;
+                        break;
+                    }
+                }
+                if (!find_valstart) {
                     tailLineSkip++;
-                } else {
+                }
+                else{
                     break;
                 }
             }

--- a/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasProductReader.java
+++ b/seadas-reader/src/main/java/gov/nasa/gsfc/seadas/dataio/SeadasProductReader.java
@@ -64,6 +64,8 @@ public class SeadasProductReader extends AbstractProductReader {
         Level1B_PaceOCIS("PaceOCIS_L1B"),
         Level2("Level 2"),
         Level2_DscovrEpic("DscovrEpic Level 2"),
+        Level2_PaceOCI("OCI Level-2"),
+        Level2_PaceOCIS("OCIS Level-2"),
         Level3_Bin("Level 3 Binned"),
         MEaSUREs("MEaSUREs Mapped"),
         MEaSUREs_Bin("MEaSUREs Binned"),
@@ -120,6 +122,8 @@ public class SeadasProductReader extends AbstractProductReader {
                 case Level1B:
                 case Level1A_CZCS:
                 case Level2_CZCS:
+                case Level2_PaceOCI:
+                case Level2_PaceOCIS:
                     seadasFileReader = new L2FileReader(this);
                     break;
                 case Level2_DscovrEpic:
@@ -334,6 +338,10 @@ public class SeadasProductReader extends AbstractProductReader {
                 return ProductType.Level1B_PaceOCI;
             } else if (title.contains("PACE OCIS Level-1B Data")) {
                 return ProductType.Level1B_PaceOCIS;
+            } else if (title.equals("OCIS Level-2 Data")) {
+                return ProductType.Level2_PaceOCIS;
+            } else if (title.equals("OCI Level-2 Data")) {
+                return ProductType.Level2_PaceOCI;
             } else if (title.contains("Level-1B")) {
                 return ProductType.Level1B;
             } else if (title.equals("CZCS Level-1A Data")) {


### PR DESCRIPTION
Modifications to seadas-reader in this pull-request:

Added 3D reader which can output 2D bands for each wavelength in the 3D input file.
Bug fix: PACE L1B/L2 files are now flipped correctly east-west.
Bug fix: MERIS L2 files (with bad nav lines) can now be read correctly.
Bug fix: HICO L1B files can now be read.