### PR TITLE
Updates for Landsat8/9 collection 2 format

### DIFF
--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/Collection2OLILandsatQA.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/Collection2OLILandsatQA.java
@@ -1,0 +1,169 @@
+package org.esa.s3tbx.dataio.landsat.geotiff;
+
+import org.esa.snap.core.datamodel.FlagCoding;
+import org.esa.snap.core.datamodel.Mask;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Definition of Landsat8/9 QA flags
+ * @author Cosmin Cara
+ */
+public class Collection2OLILandsatQA extends AbstractLandsatQA {
+
+    private final static Map<String, List<FlagCodingArgs>> codings = new HashMap<String, List<FlagCodingArgs>>() {{
+        put("FILE_NAME_QUALITY_L1_PIXEL",
+                new ArrayList<FlagCodingArgs>() {{
+                    int position = 1;
+                    add(new FlagCodingArgs("designated_fill", position, "Designated Fill"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("dillated_cloud", position, "Dillated Cloud"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cirrus", position, "Cirrus"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud", position, "Cloud"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud_shadow", position, "Cloud Shadow"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("snow", position, "Snow/Ice Cover"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("water", position, "Water"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud_confidence_one", position, "Cloud confidence bit one"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud_confidence_two", position, "Cloud confidence bit two"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud_shadow_confidence_one", position, "Cloud shadow confidence bit one"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cloud_shadow_confidence_two", position, "Cloud shadow confidence bit two"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("snow_ice_confidence_one", position, "Snow/ice confidence bit one"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("snow_ice_confidence_two", position, "Snow/ice confidence bit two"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cirrus_confidence_one", position, "Cirrus confidence bit one"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("cirrus_confidence_two", position, "Cirrus confidence bit two"));
+                }});
+        put("FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION",
+                new ArrayList<FlagCodingArgs>() {{
+                    int position = 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b1", position, "Band 1 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b2", position, "Band 2 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b3", position, "Band 3 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b4", position, "Band 4 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b5", position, "Band 5 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b6", position, "Band 6 data saturation"));
+                    position <<= 1;
+                    add(new FlagCodingArgs("radiometric_saturation_b7", position, "Band 7 data saturation"));
+                    position <<= 2; // position 7 not used
+                    add(new FlagCodingArgs("radiometric_saturation_b9", position, "Band 9 data saturation"));
+                    position <<= 3; // positions 9 and 10 not used
+                    add(new FlagCodingArgs("terrain_occlusion", position, "Terrain occlusion"));
+                }});
+    }};
+
+    @Override
+    public FlagCoding createFlagCoding(String bandName) {
+        final FlagCoding flagCoding = new FlagCoding(bandName);
+        final List<FlagCodingArgs> args;
+        if (bandName.equals("flags")) {
+            args = codings.get("FILE_NAME_QUALITY_L1_PIXEL");
+        } else {
+            args = codings.get("FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION");
+        }
+        args.forEach(a -> flagCoding.addFlag(a.getName(), a.getFlagMask(), a.getDescription()));
+        return flagCoding;
+    }
+
+    @Override
+    public List<Mask> createMasks(Dimension size) {
+        ArrayList<Mask> masks = new ArrayList<>();
+        final int width = size.width;
+        final int height = size.height;
+
+        masks.add(Mask.BandMathsType.create("designated_fill",
+                "Designated Fill",
+                width, height,
+                "flags.designated_fill",
+                colorIterator.next(),
+                0.5));
+        masks.add(Mask.BandMathsType.create("terrain_occlusion",
+                "Terrain Occlusion",
+                width, height,
+                "satflags.terrain_occlusion",
+                colorIterator.next(),
+                0.5));
+        masks.add(Mask.BandMathsType.create("cloud",
+                "Cloud",
+                width, height,
+                "flags.cloud",
+                colorIterator.next(),
+                0.5));
+        //masks.addAll(createDefaultRadiometricSaturationMasks("radiometric_saturation", "Radiometric saturation", width, height));
+        masks.add(Mask.BandMathsType.create("Saturation for band 1", "Saturation for band 1",
+                width, height, "satflags.radiometric_saturation_b1",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 2", "Saturation for band 2",
+                width, height, "satflags.radiometric_saturation_b2",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 3", "Saturation for band 3",
+                width, height, "satflags.radiometric_saturation_b3",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 4", "Saturation for band 4",
+                width, height, "satflags.radiometric_saturation_b4",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 5", "Saturation for band 5",
+                width, height, "satflags.radiometric_saturation_b5",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 6", "Saturation for band 6",
+                width, height, "satflags.radiometric_saturation_b6",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 7", "Saturation for band 7",
+                width, height, "satflags.radiometric_saturation_b7",
+                colorIterator.next(), 0.5));
+        masks.add(Mask.BandMathsType.create("Saturation for band 9", "Saturation for band 9",
+                width, height, "satflags.radiometric_saturation_b9",
+                colorIterator.next(), 0.5));
+        masks.addAll(createDefaultConfidenceMasks("snow_ice_confidence", "Snow/ice confidence", width, height));
+        masks.addAll(createDefaultConfidenceMasks("cloud_confidence", "Cloud confidence", width, height));
+        masks.addAll(createDefaultConfidenceMasks("cloud_shadow_confidence", "Cloud shadow confidence", width, height));
+        masks.addAll(createDefaultConfidenceMasks("cirrus_confidence", "Cirrus confidence", width, height));
+
+
+        return masks;
+    }
+
+    private static class FlagCodingArgs {
+        final String name;
+        final int flagMask;
+        final String description;
+
+        FlagCodingArgs(String name, int flagMask, String description) {
+            this.name = name;
+            this.flagMask = flagMask;
+            this.description = description;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getFlagMask() {
+            return flagMask;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+    }
+}

--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/Landsat8C2Metadata.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/Landsat8C2Metadata.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (C) 2011 Brockmann Consult GmbH (info@brockmann-consult.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 3 of the License, or (at your option)
+ * any later version.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, see http://www.gnu.org/licenses/
+ */
+
+package org.esa.s3tbx.dataio.landsat.geotiff;
+
+import org.esa.snap.core.datamodel.MetadataAttribute;
+import org.esa.snap.core.datamodel.MetadataElement;
+import org.esa.snap.core.datamodel.ProductData;
+import org.esa.snap.runtime.Config;
+
+import java.awt.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.logging.Logger;
+import java.util.prefs.Preferences;
+import java.util.regex.Pattern;
+
+/**
+ * @author Thomas Storm
+ */
+class Landsat8C2Metadata extends AbstractLandsatMetadata {
+    private static final double DEFAULT_SCALE_FACTOR = 1.0;
+    private static final double DEFAULT_OFFSET = 0.0;
+
+    private static final Preferences PREFERENCES = Config.instance("s3tbx").load().preferences();
+    private static final Logger LOG = Logger.getLogger(Landsat8Metadata.class.getName());
+
+    private static final String[] BAND_DESCRIPTIONS = {
+            "Coastal Aerosol (Operational Land Imager (OLI))",
+            "Blue (OLI)",
+            "Green (OLI)",
+            "Red (OLI)",
+            "Near-Infrared (NIR) (OLI)",
+            "Short Wavelength Infrared (SWIR) 1 (OLI)",
+            "SWIR 2 (OLI)",
+            "Panchromatic (OLI)",
+            "Cirrus (OLI)",
+            "Thermal Infrared Sensor (TIRS) 1",
+            "TIRS 2"
+    };
+
+    private static final float[] WAVELENGTHS = {
+            440,
+            480,
+            560,
+            655,
+            865,
+            1610,
+            2200,
+            590,
+            1370,
+            10895,
+            12005
+    };
+    private static final String[] BAND_NAMES = {
+            "coastal_aerosol",
+            "blue",
+            "green",
+            "red",
+            "near_infrared",
+            "swir_1",
+            "swir_2",
+            "panchromatic",
+            "cirrus",
+            "thermal_infrared_(tirs)_1",
+            "thermal_infrared_(tirs)_2",
+    };
+
+    private static final float[] BANDWIDTHS = {
+            20,
+            60,
+            60,
+            30,
+            30,
+            80,
+            180,
+            180,
+            20,
+            590,
+            1010
+    };
+
+    public Landsat8C2Metadata(Reader fileReader) throws IOException {
+        super(fileReader);
+    }
+
+    public Landsat8C2Metadata(MetadataElement root) throws IOException {
+        super(root);
+    }
+
+    @Override
+    public MetadataElement getProductMetadata() {
+        return getMetaDataElementRoot().getElement("PRODUCT_CONTENTS");
+    }
+
+    @Override
+    public Dimension getReflectanceDim() {
+        return getDimension("REFLECTIVE_SAMPLES", "REFLECTIVE_LINES");
+    }
+
+    @Override
+    public Dimension getThermalDim() {
+        return getDimension("THERMAL_SAMPLES", "THERMAL_LINES");
+    }
+
+    @Override
+    public Dimension getPanchromaticDim() {
+        return getDimension("PANCHROMATIC_SAMPLES", "PANCHROMATIC_LINES");
+    }
+
+    @Override
+    public String getProductType() {
+        return getProductType("PROCESSING_LEVEL");
+    }
+
+    @Override
+    public double getScalingFactor(String bandId) {
+        final String spectralInput = getSpectralInputString();
+        String attributeKey = String.format("%s_MULT_BAND_%s", spectralInput, bandId);
+        MetadataElement radiometricRescalingElement = getMetaDataElementRoot().getElement("LEVEL1_RADIOMETRIC_RESCALING");
+        if (radiometricRescalingElement.getAttribute(attributeKey) == null) {
+            return DEFAULT_SCALE_FACTOR;
+        }
+
+        final double scalingFactor = radiometricRescalingElement.getAttributeDouble(attributeKey);
+        final double sunAngleCorrectionFactor = getSunAngleCorrectionFactor(spectralInput);
+
+        return scalingFactor / sunAngleCorrectionFactor;
+    }
+
+    @Override
+    public double getScalingOffset(String bandId) {
+        final String spectralInput = getSpectralInputString();
+        String attributeKey = String.format("%s_ADD_BAND_%s", spectralInput, bandId);
+        MetadataElement radiometricRescalingElement = getMetaDataElementRoot().getElement("LEVEL1_RADIOMETRIC_RESCALING");
+        if (radiometricRescalingElement.getAttribute(attributeKey) == null) {
+            return DEFAULT_OFFSET;
+        }
+
+        final double scalingOffset = radiometricRescalingElement.getAttributeDouble(attributeKey);
+        final double sunAngleCorrectionFactor = getSunAngleCorrectionFactor(spectralInput);
+
+        return scalingOffset / sunAngleCorrectionFactor;
+    }
+
+    @Override
+    public ProductData.UTC getCenterTime() {
+        return getCenterTime("DATE_ACQUIRED", "SCENE_CENTER_TIME");
+    }
+
+    @Override
+    public Pattern getOpticalBandFileNamePattern() {
+        return Pattern.compile("FILE_NAME_BAND_(\\d{1,2})");
+    }
+
+    @Override
+    public String getQualityBandNameKey() {
+        return "FILE_NAME_QUALITY_L1";
+    }
+
+    @Override
+    public float getWavelength(String bandIndexNumber) {
+        int index = getIndex(bandIndexNumber);
+        return WAVELENGTHS[index];
+    }
+
+    @Override
+    public float getBandwidth(String bandIndexNumber) {
+        int index = getIndex(bandIndexNumber);
+        return BANDWIDTHS[index];
+    }
+
+    @Override
+    public String getBandDescription(String bandNumber) {
+        int index = getIndex(bandNumber);
+        return BAND_DESCRIPTIONS[index];
+    }
+
+    @Override
+    public String getBandNamePrefix(String bandNumber) {
+        int index = getIndex(bandNumber);
+        return BAND_NAMES[index];
+    }
+
+    @Override
+    protected Dimension getDimension(String widthAttributeName, String heightAttributeName) {
+        MetadataElement metadata = getProjectionAttributes();
+        MetadataAttribute widthAttribute = metadata.getAttribute(widthAttributeName);
+        MetadataAttribute heightAttribute = metadata.getAttribute(heightAttributeName);
+        if (widthAttribute != null && heightAttribute != null) {
+            int width = widthAttribute.getData().getElemInt();
+            int height = heightAttribute.getData().getElemInt();
+            return new Dimension(width, height);
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    protected ProductData.UTC getCenterTime(String acquisitionDateKey, String sceneCenterScanTimeKey) {
+        MetadataElement metadata = getImageAttributes();
+        String dateString = metadata.getAttributeString(acquisitionDateKey);
+        String timeString = metadata.getAttributeString(sceneCenterScanTimeKey);
+
+        try {
+            if (dateString != null && timeString != null) {
+                timeString = timeString.substring(0, 12);
+                final DateFormat dateFormat = ProductData.UTC.createDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+                final Date date = dateFormat.parse(dateString + " " + timeString);
+                String milliSeconds = timeString.substring(timeString.length() - 3);
+                return ProductData.UTC.create(date, Long.parseLong(milliSeconds) * 1000);
+            }
+        } catch (ParseException ignored) {
+            // ignore
+        }
+        return null;
+    }
+
+    @Override
+    protected String getProductType(String productTypeKey) {
+        final MetadataAttribute product_type = getProductMetadata().getAttribute(productTypeKey);
+        final MetadataAttribute spacecraft_id = getImageAttributes().getAttribute("SPACECRAFT_ID");
+        final MetadataAttribute sensor_id = getImageAttributes().getAttribute("SENSOR_ID");
+
+        final StringBuilder result = new StringBuilder();
+        result.append(spacecraft_id.getData().getElemString());
+        result.append("_");
+        result.append(sensor_id.getData().getElemString());
+        result.append("_");
+        result.append(product_type.getData().getElemString());
+
+        return result.toString();
+    }
+
+    private static int getIndex(String bandIndexNumber) {
+        return Integer.parseInt(bandIndexNumber) - 1;
+    }
+
+    static String getSpectralInputString() {
+        final Preferences preferences = Config.instance("s3tbx").load().preferences();
+        final String readAs = preferences.get(LandsatGeotiffReader.SYSPROP_READ_AS, null);
+        String spectralInput;
+        if (readAs != null) {
+            switch (readAs.toLowerCase()) {
+                case "reflectance":
+                    spectralInput = "REFLECTANCE";
+                    break;
+                case "radiance":
+                    spectralInput = "RADIANCE";
+                    break;
+                default:
+                    spectralInput = "RADIANCE";
+                    LOG.warning(String.format("Property '%s' has unsupported value '%s'.%n" +
+                                    "Interpreting values as radiance.",
+                            LandsatGeotiffReader.SYSPROP_READ_AS, readAs));
+
+            }
+        }else {
+            spectralInput = "RADIANCE";
+        }
+        return spectralInput;
+    }
+
+    private double getSunAngleCorrectionFactor(String spectralInput) {
+        // this follows:
+        // http://landsat.usgs.gov/Landsat8_Using_Product.php, section 'Conversion to TOA Reflectance'
+        double sunAngleCorrectionFactor = 1.0;
+        if (spectralInput.equals("REFLECTANCE")) {
+            MetadataElement imageAttributesElement = getMetaDataElementRoot().getElement("IMAGE_ATTRIBUTES");
+            if (imageAttributesElement != null) {
+                final String sunElevationAttributeKey = "SUN_ELEVATION";
+                if (imageAttributesElement.getAttribute(sunElevationAttributeKey) != null) {
+                    final double sunElevationAngle = imageAttributesElement.getAttributeDouble(sunElevationAttributeKey);
+                    sunAngleCorrectionFactor = Math.sin(Math.toRadians(sunElevationAngle));
+                }
+            }
+        }
+        return sunAngleCorrectionFactor;
+    }
+
+    private MetadataElement getProductContents() {
+        return getMetaDataElementRoot().getElement("PRODUCT_CONTENTS");
+    }
+
+    private MetadataElement getImageAttributes() {
+        return getMetaDataElementRoot().getElement("IMAGE_ATTRIBUTES");
+    }
+
+    private MetadataElement getProjectionAttributes() {
+        return getMetaDataElementRoot().getElement("PROJECTION_ATTRIBUTES");
+    }
+}

--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatGeotiffReaderPlugin.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatGeotiffReaderPlugin.java
@@ -25,11 +25,7 @@ import org.esa.snap.core.util.StringUtils;
 import org.esa.snap.core.util.io.FileUtils;
 import org.esa.snap.core.util.io.SnapFileFilter;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.util.Locale;
 
 /**
@@ -102,7 +98,9 @@ public class LandsatGeotiffReaderPlugin implements ProductReaderPlugIn {
         } catch (IOException e) {
             return false;
         }
-        return firstLine != null && firstLine.trim().matches("GROUP = L1_METADATA_FILE");
+        return firstLine != null &&
+                (firstLine.trim().matches("GROUP = L1_METADATA_FILE") ||
+                        firstLine.trim().matches("GROUP = LANDSAT_METADATA_FILE"));
     }
 
     @Override

--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatLegacyMetadata.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatLegacyMetadata.java
@@ -19,7 +19,7 @@ package org.esa.s3tbx.dataio.landsat.geotiff;
 import org.esa.snap.core.datamodel.MetadataElement;
 import org.esa.snap.core.datamodel.ProductData;
 
-import java.awt.Dimension;
+import java.awt.*;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.HashMap;
@@ -161,7 +161,7 @@ class LandsatLegacyMetadata extends AbstractLandsatMetadata {
 
     boolean isLegacyFormat() {
         MetadataElement metadata = getProductMetadata();
-        return metadata.getAttribute("BAND1_FILE_NAME") != null;
+        return metadata != null && metadata.getAttribute("BAND1_FILE_NAME") != null;
     }
 
 }

--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatMetadataFactory.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatMetadataFactory.java
@@ -43,10 +43,15 @@ class LandsatMetadataFactory {
                 FileReader fileReader = new FileReader(mtlFile);
                 reader = new BufferedReader(fileReader);
                 String line = reader.readLine();
+                int collection = 1;
                 while (line != null) {
-                    if (line.contains("SPACECRAFT_ID")) {
+                    if (line.contains("COLLECTION_NUMBER")) {
+                        collection = Integer.parseInt(line.substring(line.indexOf('=') + 1).trim());
+                    } else if (line.contains("SPACECRAFT_ID")) {
                         if (line.contains("LANDSAT_8")) {
-                            return new Landsat8Metadata(new FileReader(mtlFile));
+                            return collection == 1 ?
+                                    new Landsat8Metadata(new FileReader(mtlFile)) :
+                                    new Landsat8C2Metadata(new FileReader(mtlFile));
                         } else {
                             return new LandsatReprocessedMetadata(new FileReader(mtlFile));
                         }

--- a/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatQAFactory.java
+++ b/s3tbx-landsat-reader/src/main/java/org/esa/s3tbx/dataio/landsat/geotiff/LandsatQAFactory.java
@@ -1,7 +1,5 @@
 package org.esa.s3tbx.dataio.landsat.geotiff;
 
-import org.esa.snap.core.dataio.ProductIOException;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -24,9 +22,11 @@ public class LandsatQAFactory {
             FileReader fileReader = new FileReader(mtlFile);
             reader = new BufferedReader(fileReader);
             String line = reader.readLine();
+            int collection = 1;
             while (line != null) {
                 if (line.contains("COLLECTION_NUMBER")) {
                     isCollectionProduct = true;
+                    collection = Integer.parseInt(line.substring(line.indexOf('=') + 1).trim());
                 }
                 if (line.contains("SENSOR_ID")) {
                     if (line.contains("OLI")) {
@@ -39,7 +39,7 @@ public class LandsatQAFactory {
                 }
 
                 if(isCollectionProduct && isMSS) return new CollectionMSSLandsatQA();
-                if(isCollectionProduct && isOLI) return new CollectionOLILandsatQA();
+                if(isCollectionProduct && isOLI) return collection == 1 ? new CollectionOLILandsatQA() : new Collection2OLILandsatQA();
                 if(isCollectionProduct && isTM) return new CollectionTMLandsatQA();
                 if(!isCollectionProduct && isOLI) return new PreCollectionLandsatQA();
 


### PR DESCRIPTION
Minimal changes to Landsat 8 Geotiff reader to support collection 2 format changes:
1. metadata (different organisation of attributes)
2. masks (masks split into two rasters in collection 2)
3. rasters (let ProductIO to decide what reader to use)