### PR TITLE
SEADAS: sentinel3 reader fixes (9.x)

### DIFF
--- a/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/meris/MerisLevel1ProductReader.java
+++ b/s3tbx-sentinel3-reader/src/main/java/org/esa/s3tbx/dataio/s3/meris/MerisLevel1ProductReader.java
@@ -17,7 +17,7 @@ public class MerisLevel1ProductReader extends Sentinel3ProductReader {
     @Override
     protected Product readProductNodesImpl() throws IOException {
         final String dirName = getInputFileParentDirectory().getName();
-        if (dirName.matches("EN.*_(F|R)R(G|P|S).*")) {
+        if (dirName.matches("EN(1|V).*_ME(R|_)1?_(F|R)R(G|P|S|_)_(1P)?_.*")) {
             setFactory(new MerisLevel1ProductFactory(this));
         }
         return createProduct();

--- a/s3tbx-sentinel3-reader/src/main/javahelp/org/esa/s3tbx/s3tbx/sentinel3/reader/docs/toc.xml
+++ b/s3tbx-sentinel3-reader/src/main/javahelp/org/esa/s3tbx/s3tbx/sentinel3/reader/docs/toc.xml
@@ -12,7 +12,7 @@
             <tocitem text="Import Raster Data">
                 <tocitem text="Optical Sensors">
                     <tocitem text="Sentinel-3" target="importSentinel3Product"/>
-                    <tocitem text="Sentinel-3 Recommended Flags" target="S3RecomFlags"/>
+                    <tocitem text="Sentinel-3 Recommended Flags" target="importS3RecomFlags"/>
                 </tocitem>
             </tocitem>
         </tocitem>


### PR DESCRIPTION
1. Fixed regular expression in MerisLevel1ProductReader to match the corrected one in MerisLevel1ProductPlugIn.
2. Fixed a broken target link in help toc.xml.